### PR TITLE
feat: Add vite client type when env.d.ts does not exist

### DIFF
--- a/src/writeEnvInterface.ts
+++ b/src/writeEnvInterface.ts
@@ -12,6 +12,9 @@ export function writeEnvInterface(path: string, envInterface: string) {
       envInterface = `${fileContent}
 ${envInterface}`
     }
+  } else {
+    envInterface = `/// <reference types="vite/client" />
+${envInterface}`
   }
   fs.writeFileSync(path, envInterface)
 }


### PR DESCRIPTION
当用户未配置
```json
{
  "compilerOptions": {
    "types": ["vite/client"]
  }
}
```
时，且删除`env.d.ts`，那么插件生成的`env.d.ts`因为未携带`/// <reference types="vite/client" />`，将导致类型缺失